### PR TITLE
Fix(AAiT-mobile-g3): Update in domain layer

### DIFF
--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/entity/article.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/entity/article.dart
@@ -6,7 +6,7 @@ class Article extends Equatable {
   final String title;
   final String subTitle;
   final String estimatedReadTime;
-  final Map<String, dynamic> user;
+  final String user;
   final String image;
   final String imageCloudinaryPublicId;
   final DateTime createdAt;
@@ -32,25 +32,14 @@ class Article extends Equatable {
           title: '_empty.title',
           subTitle: '_empty.subTitle',
           estimatedReadTime: '_empty.estimatedReadTime',
-          user: {
-            "_id": "64e25674bfc65d390e781205",
-            "fullName": "Tamirat Dereje",
-            "email": "tamiratdereje@gmail.com",
-            "expertise": "designer",
-            "bio": "I am passionate designer who see beauty in everything",
-            "createdAt": "2023-08-20T18:07:48.829Z",
-            "__v": 0,
-            "image":
-                "https://res.cloudinary.com/dzpmgwb8t/image/upload/v1692557684/guf4tul1ftar9hdpnaev.jpg",
-            "imageCloudinaryPublicId": "guf4tul1ftar9hdpnaev",
-            "id": "64e25674bfc65d390e781205"
-          },
+          user: '1',
           image: '_empty.image',
-          imageCloudinaryPublicId: '_empty.imageCludinaryPublicId',
+          imageCloudinaryPublicId: '_empty.imageCloudinaryPublicId',
           createdAt: DateTime.parse('1969-07-20 20:18:04Z'),
           id: '1',
         );
 
   @override
   List<Object?> get props => [id];
+
 }

--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/repository/article_repository.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/repository/article_repository.dart
@@ -12,10 +12,12 @@ abstract class ArticleRepository {
     required String image,
   });
   // Read Ariticle
-  ResultFuture<Article> getArticle(String id);
+  ResultFuture<List<Article>> getArticle({String? tags, String? searchParams});
+  ResultFuture<Article> getArticleById(String id);
   ResultFuture<List<Article>> getAllArticles();
   // Update Article
   ResultFuture<Article> updateArticle({
+    required String id,
     required List<String> tags,
     required String content,
     required String title,
@@ -24,7 +26,7 @@ abstract class ArticleRepository {
     required String image,
   });
   // Delete  Article
-  ResultFuture<Article> deleteArticle(String id);
+  ResultFuture<bool> deleteArticle(String id);
 
   ResultFuture<List<String>> getTags();
 }

--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/delete_article.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/delete_article.dart
@@ -1,15 +1,14 @@
 import '../../../../core/use_case/usecase.dart';
 import '../../../../core/util/typedef.dart';
-import '../entity/article.dart';
 import '../repository/article_repository.dart';
 
-class DeleteArticleUsecase implements UseCase<Article, String>{
+class DeleteArticleUsecase implements UseCase<bool, String>{
   final ArticleRepository _repository;
 
   DeleteArticleUsecase(this._repository);
 
   @override
-  ResultFuture<Article> call(String params) async {
+  ResultFuture<bool> call(String params) async {
     return _repository.deleteArticle(params);
   } 
 }

--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/get_article.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/get_article.dart
@@ -1,15 +1,41 @@
+import 'package:equatable/equatable.dart';
+
 import '../../../../core/use_case/usecase.dart';
 import '../../../../core/util/typedef.dart';
 import '../entity/article.dart';
 import '../repository/article_repository.dart';
 
-class GetArticleUsecase implements UseCase<Article, String>{
+class GetArticleUsecase implements UseCase<List<Article>, GetArticleParams>{
   final ArticleRepository _repository;
 
   GetArticleUsecase(this._repository);
 
   @override
-  ResultFuture<Article> call(String params) {
-    return _repository.getArticle(params);
+  ResultFuture<List<Article>> call(GetArticleParams params) {
+    return _repository.getArticle(
+      tags: params.tags ?? "",
+      searchParams: params.searchParams ?? "",
+    );
   }
+}
+
+class GetArticleParams extends Equatable {
+  const GetArticleParams({
+    this.tags,
+    this.searchParams
+  });
+
+
+  final String? tags;
+  final String? searchParams;
+
+  const GetArticleParams.empty()
+    :this(
+          tags: 'Other',
+          searchParams: 'wo',
+        );
+
+  @override
+  List<Object?> get props =>
+      [tags, searchParams];
 }

--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/get_article_by_id.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/get_article_by_id.dart
@@ -1,0 +1,15 @@
+import '../../../../core/use_case/usecase.dart';
+import '../../../../core/util/typedef.dart';
+import '../entity/article.dart';
+import '../repository/article_repository.dart';
+
+class GetArticleByIdUsecase implements UseCase<Article, String>{
+  final ArticleRepository _repository;
+
+  GetArticleByIdUsecase(this._repository);
+
+  @override
+  ResultFuture<Article> call(String id) {
+    return _repository.getArticleById(id);
+  }
+}

--- a/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/update_article.dart
+++ b/aait/mobile/group-3/blog_app/lib/features/article/domain/use_case/update_article.dart
@@ -11,6 +11,7 @@ class UpdateArticleUsecase implements UseCase<Article, UpdateArticleParams> {
   @override
   ResultFuture<Article> call(UpdateArticleParams params) async {
     return _repository.updateArticle(
+      id: params.id,
       tags: params.tags,
       content: params.content,
       title: params.title,
@@ -22,6 +23,7 @@ class UpdateArticleUsecase implements UseCase<Article, UpdateArticleParams> {
 }
 
 class UpdateArticleParams extends Equatable {
+  final String id;
   final List<String> tags;
   final String content;
   final String title;
@@ -30,6 +32,7 @@ class UpdateArticleParams extends Equatable {
   final String image;
 
   const UpdateArticleParams({
+    required this.id,
     required this.tags,
     required this.content,
     required this.title,
@@ -40,6 +43,7 @@ class UpdateArticleParams extends Equatable {
 
   UpdateArticleParams.empty()
       : this(
+        id: "1",
           tags: ['_empty.tags'],
           content: '_empty.content',
           title: '_empty.title',

--- a/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/create_article_test.dart
+++ b/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/create_article_test.dart
@@ -1,9 +1,11 @@
-import 'package:blog_app/features/article/domain/entity/article.dart';
-import 'package:blog_app/features/article/domain/repository/article_repository.dart';
-import 'package:blog_app/features/article/domain/use_case/create_article.dart';
+
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'package:blog_app/features/article/domain/entity/article.dart';
+import 'package:blog_app/features/article/domain/repository/article_repository.dart';
+import 'package:blog_app/features/article/domain/use_case/create_article.dart';
 
 import 'article_repository.mock.dart';
 

--- a/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/delete_article_test.dart
+++ b/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/delete_article_test.dart
@@ -1,10 +1,10 @@
 
-import 'package:blog_app/features/article/domain/entity/article.dart';
-import 'package:blog_app/features/article/domain/repository/article_repository.dart';
-import 'package:blog_app/features/article/domain/use_case/delete_article.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'package:blog_app/features/article/domain/repository/article_repository.dart';
+import 'package:blog_app/features/article/domain/use_case/delete_article.dart';
 
 import 'article_repository.mock.dart';
 
@@ -16,16 +16,15 @@ void main() {
     repository = MockArticleRepository();
     usecase = DeleteArticleUsecase(repository);
   });
-  final article = Article.empty();
   const id = "1";
   test("should call [ArticleRepository.deleteArticle]",
      () async {
     // Arrange
-    when(()=> repository.deleteArticle(any())).thenAnswer((_) async => Right(Article.empty()));
+    when(()=> repository.deleteArticle(any())).thenAnswer((_) async => const Right(true));
     // Act
     final result = await usecase(id);
     // Assert
-    expect(result, Right<dynamic, Article>(article));
+    expect(result, const Right<dynamic, bool>(true));
     verify(() => repository.deleteArticle(id)).called(1);
     verifyNoMoreInteractions(repository);
   });

--- a/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/get_article_test.dart
+++ b/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/get_article_test.dart
@@ -1,9 +1,11 @@
-import 'package:blog_app/features/article/domain/entity/article.dart';
-import 'package:blog_app/features/article/domain/repository/article_repository.dart';
-import 'package:blog_app/features/article/domain/use_case/get_article.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'package:blog_app/features/article/data/models/article_model.dart';
+import 'package:blog_app/features/article/domain/entity/article.dart';
+import 'package:blog_app/features/article/domain/repository/article_repository.dart';
+import 'package:blog_app/features/article/domain/use_case/get_article.dart';
 
 import 'article_repository.mock.dart';
 
@@ -16,18 +18,19 @@ void main() {
     usecase = GetArticleUsecase(repository);
   });
 
-  test("should call [ArticleReository.getArticle]",
-     () async {
+  test("should call [ArticleReository.getArticle]", () async {
     // Arrange
-    final article = Article.empty();
-    const id = "1";
-    when(() => repository.getArticle(any())).thenAnswer((_) async => Right(article));
+    const params = GetArticleParams.empty();
+    final articles = [ArticleModel.empty()];
+    when(() => repository.getArticle(
+            tags: any(named: 'tags'), searchParams: any(named: 'searchParams')))
+        .thenAnswer((_) async => Right(articles));
     // Act
-    final result = await usecase(id);
+    final result = await usecase(params);
     // Assert
-    expect(result, Right<dynamic, Article>(article));
-    verify(() => repository.getArticle(id)).called(1);
+    expect(result, Right<dynamic, List<Article>>(articles));
+    verify(() => repository.getArticle(tags: 'Other', searchParams: 'wo'))
+        .called(1);
     verifyNoMoreInteractions(repository);
   });
-
 }

--- a/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/get_tags_test.dart
+++ b/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/get_tags_test.dart
@@ -1,9 +1,10 @@
-import 'package:blog_app/core/use_case/usecase.dart';
-import 'package:blog_app/features/article/domain/repository/article_repository.dart';
-import 'package:blog_app/features/article/domain/use_case/get_tags.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'package:blog_app/core/use_case/usecase.dart';
+import 'package:blog_app/features/article/domain/repository/article_repository.dart';
+import 'package:blog_app/features/article/domain/use_case/get_tags.dart';
 
 import 'article_repository.mock.dart';
 

--- a/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/update_article_test.dart
+++ b/aait/mobile/group-3/blog_app/test/features/article/domain/use_case/update_article_test.dart
@@ -1,9 +1,10 @@
-import 'package:blog_app/features/article/domain/entity/article.dart';
-import 'package:blog_app/features/article/domain/repository/article_repository.dart';
-import 'package:blog_app/features/article/domain/use_case/update_article.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'package:blog_app/features/article/domain/entity/article.dart';
+import 'package:blog_app/features/article/domain/repository/article_repository.dart';
+import 'package:blog_app/features/article/domain/use_case/update_article.dart';
 
 import 'article_repository.mock.dart';
 
@@ -21,6 +22,7 @@ void main() {
     final article = Article.empty();
     final params = UpdateArticleParams.empty();
     when(() => repository.updateArticle(
+          id: any(named: 'id'),
           tags: any(named: 'tags'),
           content: any(named: 'content'),
           title: any(named: 'title'),
@@ -33,7 +35,9 @@ void main() {
     // Assert
 
     expect(result, Right<dynamic, Article>(article));
-    verify(() => repository.updateArticle(tags: any(named: 'tags'),
+    verify(() => repository.updateArticle(
+          id: any(named: 'id'),
+          tags: any(named: 'tags'),
           content: any(named: 'content'),
           title: any(named: 'title'),
           subTitle: any(named: 'subTitle'),


### PR DESCRIPTION
**Update in the domain layer:**

- Modified the user field in the article entity from a map to a string representing the author's id for better clarity.
- Added the 'id' field as a parameter in the update article use case to facilitate targeted updates.
- Expanded the parameter of the get article use case to include 'tags' and 'searchParam' fields, providing more refined querying capabilities.
- Introduced a new use case - 'get_article_by_id' - to retrieve an article based on its unique id.
- Adjusted the return type of the delete article use case to 'bool' to indicate the success or failure of the deletion operation.
- Updated the related tests to reflect these changes and ensure compatibility with the new use cases and parameters.

Feel free to review and provide feedback. 
Thank you!
