### PR TITLE
feat(AAiT-mobile-2): Add Bloc to Create Article Screen

### DIFF
--- a/aait/mobile/group-2/blog_app/android/app/src/main/AndroidManifest.xml
+++ b/aait/mobile/group-2/blog_app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    
+    <uses-permission android:name="android.permission.INTERNET"/>
+    
     <application
         android:label="blog_app"
         android:name="${applicationName}"

--- a/aait/mobile/group-2/blog_app/lib/bloc_observer.dart
+++ b/aait/mobile/group-2/blog_app/lib/bloc_observer.dart
@@ -1,0 +1,29 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SimpleBlocObserver extends BlocObserver {
+  @override
+  void onEvent(Bloc bloc, Object? event) {
+    super.onEvent(bloc, event);
+    log('[bloc] ${bloc.runtimeType} $event');
+  }
+
+  @override
+  onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    log('[bloc] ${bloc.runtimeType} $transition');
+  }
+
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    super.onChange(bloc, change);
+    log('[bloc] ${bloc.runtimeType} $change');
+  }
+
+  @override
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    log('[bloc] onError $error');
+  }
+}

--- a/aait/mobile/group-2/blog_app/lib/core/presentation/router/router.dart
+++ b/aait/mobile/group-2/blog_app/lib/core/presentation/router/router.dart
@@ -1,5 +1,6 @@
 import 'package:go_router/go_router.dart';
 
+import '../../../features/article/domain/entities/article.dart';
 import '../../../features/article/presentation/screens/screens.dart';
 import 'routes.dart';
 
@@ -8,15 +9,18 @@ final GoRouter router = GoRouter(
 
   routes: <RouteBase>[
     GoRoute(
-      path: Routes.home,
-      builder: (context, state) => const ArticleScreen(articleId: '1'),
+      path: Routes.createArticle,
+      builder: (context, state) => const ArticleFormScreen(),
     ),
     GoRoute(
       path: Routes.articleDetail,
-      builder: (context, state) => const ArticleScreen(articleId: '1'),
+      builder: (context, state) {
+        final article = state.extra as Article;
+        return ArticleScreen(article: article);
+      },
     ),
     GoRoute(
-      path: Routes.createArticle,
+      path: Routes.home,
       builder: (context, state) => const ArticleFormScreen(),
     ),
   ],

--- a/aait/mobile/group-2/blog_app/lib/core/presentation/theme/app_colors.dart
+++ b/aait/mobile/group-2/blog_app/lib/core/presentation/theme/app_colors.dart
@@ -6,17 +6,18 @@ abstract class AppColors {
 
   static const lightBlue = Color(0xFF669AFF);
   static const blue = Color(0xFF376AED);
+  static const translucentBlue = Color(0x26376AED);
   static const saturatedBlue = Color(0xFF2151CD);
   static const darkBlue = Color(0xFF2D4379);
   static const darkerBlue = Color(0xFF0D253C);
 
   static const darkGray = Color(0xFF7B8BB2);
 
-  static const gray50 = Color(0x427B8BB2);
   static const gray100 = Color(0xFFF8FAFF);
   static const gray200 = Color(0xFFD7DDEB);
   static const gray300 = Color(0xFF979EA5);
   static const gray400 = Color(0xFF878585);
+  static const gray500 = Color(0x427B8BB2);
 
   static const red = Color(0xFFCC3926);
 }

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_bloc.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_bloc.dart
@@ -5,7 +5,11 @@ import '../../domain/usecases/usecases.dart';
 import 'article_event.dart';
 import 'article_state.dart';
 
+export 'article_event.dart';
+export 'article_state.dart';
+
 class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
+  final GetTags getTags;
   final GetArticle getArticle;
   final GetAllArticles getAllArticles;
   final CreateArticle createArticle;
@@ -13,6 +17,7 @@ class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
   final DeleteArticle deleteArticle;
 
   ArticleBloc({
+    required this.getTags,
     required this.getArticle,
     required this.getAllArticles,
     required this.createArticle,
@@ -21,9 +26,20 @@ class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
   }) : super(ArticleInitialState()) {
     on<GetSingleArticleEvent>(_getArticle);
     on<LoadAllArticlesEvent>(_getAllArticles);
+    on<LoadAllTagsEvent>(_getTags);
     on<CreateArticleEvent>(_createArticle);
     on<UpdateArticleEvent>(_updateArticle);
     on<DeleteArticleEvent>(_deleteArticle);
+  }
+
+  Future<void> _getTags(
+      LoadAllTagsEvent event, Emitter<ArticleState> emit) async {
+    final result = await getTags(NoParams());
+
+    result.fold(
+      (failure) => emit(ArticleErrorState(failure.toString())),
+      (tags) => emit(AllTagsLoadedState(tags)),
+    );
   }
 
   Future<void> _getArticle(

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_event.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_event.dart
@@ -11,6 +11,8 @@ sealed class ArticleEvent extends Equatable {
 
 final class LoadAllArticlesEvent extends ArticleEvent {}
 
+final class LoadAllTagsEvent extends ArticleEvent {}
+
 final class GetSingleArticleEvent extends ArticleEvent {
   final String id;
 

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_state.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/article_state.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 import '../../domain/entities/article.dart';
+import '../../domain/entities/tag.dart';
 
 sealed class ArticleState extends Equatable {
   const ArticleState();
@@ -12,6 +13,8 @@ sealed class ArticleState extends Equatable {
 final class ArticleInitialState extends ArticleState {}
 
 final class ArticleLoadingState extends ArticleState {}
+
+final class TagLoadingState extends ArticleState {}
 
 final class SingleArticleLoadedState extends ArticleState {
   final Article article;
@@ -29,6 +32,15 @@ final class AllArticlesLoadedState extends ArticleState {
 
   @override
   List<Object> get props => [articles];
+}
+
+final class AllTagsLoadedState extends ArticleState {
+  final List<Tag> tags;
+
+  const AllTagsLoadedState(this.tags);
+
+  @override
+  List<Object> get props => [tags];
 }
 
 final class ArticleCreatedState extends ArticleState {

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_bloc.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_bloc.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/entities/tag.dart';
+import 'tag_selector_event.dart';
+import 'tag_selector_state.dart';
+
+export 'tag_selector_event.dart';
+export 'tag_selector_state.dart';
+
+class TagSelectorBloc extends Bloc<TagSelectorEvent, TagSelectorState> {
+  final selectedTags = <Tag>{};
+
+  TagSelectorBloc() : super(const TagSelectorState([])) {
+    on<AddTagEvent>(_addTag);
+    on<RemoveTagEvent>(_removeTag);
+  }
+
+  void _addTag(AddTagEvent event, Emitter<TagSelectorState> emit) {
+    selectedTags.add(event.tag);
+    emit(TagSelectorState(List.from(selectedTags)));
+  }
+
+  void _removeTag(RemoveTagEvent event, Emitter<TagSelectorState> emit) {
+    selectedTags.remove(event.tag);
+    emit(TagSelectorState(List.from(selectedTags)));
+  }
+}

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_event.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_event.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+
+import '../../domain/entities/tag.dart';
+
+sealed class TagSelectorEvent extends Equatable {
+  const TagSelectorEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AddTagEvent extends TagSelectorEvent {
+  final Tag tag;
+
+  const AddTagEvent(this.tag);
+}
+
+class RemoveTagEvent extends TagSelectorEvent {
+  final Tag tag;
+
+  const RemoveTagEvent(this.tag);
+}

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_state.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/bloc/tag_selector_state.dart
@@ -1,0 +1,12 @@
+import 'package:equatable/equatable.dart';
+
+import '../../domain/entities/tag.dart';
+
+class TagSelectorState extends Equatable {
+  final List<Tag> tags;
+
+  const TagSelectorState(this.tags);
+
+  @override
+  List<Object?> get props => [tags];
+}

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/screens/article_screen.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/screens/article_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../../../../core/presentation/theme/app_colors.dart';
+import '../../domain/entities/article.dart';
 import '../widgets/article_content.dart';
 import '../widgets/article_image.dart';
 import '../widgets/author_card.dart';
@@ -9,9 +10,9 @@ import '../widgets/gradient_scroll_view.dart';
 import '../widgets/like_button.dart';
 
 class ArticleScreen extends StatelessWidget {
-  final String articleId;
+  final Article article;
 
-  const ArticleScreen({super.key, required this.articleId});
+  const ArticleScreen({super.key, required this.article});
 
   @override
   Widget build(BuildContext context) {
@@ -63,16 +64,15 @@ class ArticleScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Four Things Every One Needs To Know',
+              Text(article.title,
                   style: Theme.of(context).textTheme.titleLarge),
 
               SizedBox(height: 35.h),
 
               // Author card
-              const AuthorCard(
-                profileImageUrl:
-                    'https://res.cloudinary.com/dzpmgwb8t/image/upload/v1692557684/guf4tul1ftar9hdpnaev.jpg',
-                authorName: 'Richard Gervain',
+              AuthorCard(
+                profileImageUrl: article.author.image,
+                authorName: article.author.fullName,
                 publishedAt: '2m ago',
               ),
             ],
@@ -81,18 +81,12 @@ class ArticleScreen extends StatelessWidget {
         SizedBox(height: 30.h),
 
         // Article image
-        const ArticleImage(
-            imageUrl:
-                'https://res.cloudinary.com/dzpmgwb8t/image/upload/v1692557684/guf4tul1ftar9hdpnaev.jpg'),
+        ArticleImage(imageUrl: article.photoUrl),
         const SizedBox(height: 15),
 
         // Article content
-        const ArticleContent(
-          paragraphs: [
-            'That marked a turnaround from last year, when the social network reported a decline in users for the first time.',
-            'The drop wiped billions from the firm\'s market value.',
-            'Since executives disclosed the fall in February, the firm\'s share price has nearly halved. But shares jumped 19% in after-hours trade on Wednesday.',
-          ],
+        ArticleContent(
+          paragraphs: [article.content],
         ),
         SizedBox(height: 100.h)
       ]),

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/create_article_form.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/create_article_form.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../../core/presentation/theme/app_colors.dart';
+import '../../../user/domain/entities/user_data.dart';
+import '../../domain/entities/article.dart';
+import '../bloc/article_bloc.dart';
+import '../bloc/tag_selector_bloc.dart';
+import 'custom_chip.dart';
+import 'custom_text_field.dart';
+import 'multiline_text_field.dart';
+import 'tag_selector.dart';
+
+class CreateArticleForm extends StatefulWidget {
+  const CreateArticleForm({super.key});
+
+  @override
+  State<CreateArticleForm> createState() => _CreateArticleFormState();
+}
+
+class _CreateArticleFormState extends State<CreateArticleForm> {
+  final titleFieldController = TextEditingController();
+  final subtitleFieldController = TextEditingController();
+  final contentFieldController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: EdgeInsets.symmetric(
+        horizontal: 45.w,
+        vertical: 45.h,
+      ),
+      child: Form(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Title field
+            CustomTextField(
+              controller: titleFieldController,
+              hintText: 'Add title',
+            ),
+            const SizedBox(height: 15),
+
+            // Subtitle field
+            CustomTextField(
+              controller: subtitleFieldController,
+              hintText: 'Add subtitle',
+            ),
+            const SizedBox(height: 15),
+
+            // Tag field
+            BlocBuilder<ArticleBloc, ArticleState>(
+              builder: (context, state) {
+                if (state is AllTagsLoadedState) {
+                  return TagSelector(tags: state.tags);
+                }
+
+                return const CustomTextField(
+                  hintText: 'Add tags',
+                );
+              },
+            ),
+            const SizedBox(height: 5),
+            const Text(
+              'add as many tags as you want',
+              style: TextStyle(
+                color: AppColors.gray300,
+                fontFamily: 'Poppins',
+                fontSize: 13,
+                fontWeight: FontWeight.w200,
+              ),
+            ),
+            const SizedBox(height: 15),
+
+            // Selected tags
+            SizedBox(
+              width: double.infinity,
+              child: BlocBuilder<TagSelectorBloc, TagSelectorState>(
+                builder: (context, state) {
+                  return Wrap(
+                    runSpacing: 10,
+                    spacing: 10,
+                    children: state.tags
+                        .map((tag) => CustomChip(
+                              label: tag.name,
+                              onDelete: () {
+                                context
+                                    .read<TagSelectorBloc>()
+                                    .add(RemoveTagEvent(tag));
+                              },
+                            ))
+                        .toList(),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 30),
+
+            // Content field
+            MultilineTextInput(
+              controller: contentFieldController,
+              hintText: 'Article content',
+            ),
+            const SizedBox(height: 50),
+
+            // Create article button
+            Center(
+              child: ElevatedButton(
+                onPressed: () => _publishArticle(context),
+                child: const Text('Publish'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _publishArticle(BuildContext context) async {
+    final articleBloc = context.read<ArticleBloc>();
+    final tagsBloc = context.read<TagSelectorBloc>();
+
+    final picker = ImagePicker();
+
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+
+    if (pickedFile != null) {
+      final article = Article(
+        id: '',
+        title: titleFieldController.text,
+        subTitle: subtitleFieldController.text,
+        content: contentFieldController.text,
+        photoUrl: pickedFile.path,
+        tags: tagsBloc.selectedTags.toList(),
+        author: const UserData(
+            articles: [],
+            bio: '',
+            createdAt: '',
+            email: '',
+            expertise: '',
+            fullName: '',
+            id: '',
+            image: '',
+            imageCloudinaryPublicId: ''),
+        date: DateTime.now(),
+        estimatedReadTime: '3min',
+      );
+      articleBloc.add(CreateArticleEvent(article));
+    }
+  }
+}

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/custom_chip.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/custom_chip.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import '../../../../core/presentation/theme/app_colors.dart';
 
 class CustomChip extends StatelessWidget {
   final String label;
+  final VoidCallback onDelete;
 
-  const CustomChip({super.key, required this.label});
+  const CustomChip({super.key, required this.label, required this.onDelete});
 
   @override
   Widget build(BuildContext context) {
@@ -11,7 +13,7 @@ class CustomChip extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(15, 4, 4, 4),
       decoration: BoxDecoration(
         border: Border.all(
-          color: const Color(0xFF376AED),
+          color: AppColors.blue,
           width: 2,
         ),
         borderRadius: BorderRadius.circular(75),
@@ -22,7 +24,7 @@ class CustomChip extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              color: Color(0xFF376AED),
+              color: AppColors.blue,
               fontFamily: 'Poppins',
               fontSize: 12,
               fontWeight: FontWeight.w500,
@@ -32,14 +34,14 @@ class CustomChip extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(6),
             decoration: BoxDecoration(
-              color: const Color(0x26376AED),
+              color: AppColors.translucentBlue,
               borderRadius: BorderRadius.circular(75),
             ),
             child: GestureDetector(
-              onTap: () {},
+              onTap: onDelete,
               child: const Icon(
                 Icons.close,
-                color: Color(0xFF376AED),
+                color: AppColors.blue,
                 size: 15,
               ),
             ),

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/custom_text_field.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/custom_text_field.dart
@@ -4,12 +4,21 @@ import '../../../../core/presentation/theme/app_colors.dart';
 
 class CustomTextField extends StatelessWidget {
   final String hintText;
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
 
-  const CustomTextField({super.key, required this.hintText});
+  const CustomTextField({
+    super.key,
+    required this.hintText,
+    this.controller,
+    this.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      controller: controller,
+      focusNode: focusNode,
       style: const TextStyle(
         color: AppColors.darkerBlue,
         fontFamily: 'Poppins',
@@ -21,17 +30,17 @@ class CustomTextField extends StatelessWidget {
         ),
         border: const UnderlineInputBorder(
           borderSide: BorderSide(
-            color: AppColors.gray50,
+            color: AppColors.gray500,
           ),
         ),
         enabledBorder: const UnderlineInputBorder(
           borderSide: BorderSide(
-            color: AppColors.gray50,
+            color: AppColors.gray500,
           ),
         ),
         focusedBorder: const UnderlineInputBorder(
           borderSide: BorderSide(
-            color: AppColors.gray50,
+            color: AppColors.gray500,
           ),
         ),
         hintText: hintText,

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/snackbar.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/snackbar.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+void showError(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+        content: Text(message),
+        backgroundColor: Theme.of(context).colorScheme.error),
+  );
+}
+
+void showMessge(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(message),
+    ),
+  );
+}
+
+void showSuccess(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+        content: Text(message),
+        backgroundColor: Theme.of(context).colorScheme.primary),
+  );
+}

--- a/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/tag_selector.dart
+++ b/aait/mobile/group-2/blog_app/lib/features/article/presentation/widgets/tag_selector.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../core/presentation/theme/app_colors.dart';
+import '../../domain/entities/tag.dart';
+import '../bloc/tag_selector_bloc.dart';
+import 'custom_text_field.dart';
+
+class TagSelector extends StatelessWidget {
+  final List<Tag> tags;
+
+  TextEditingController? controller;
+  FocusNode? textFieldFocusNode;
+
+  TagSelector({super.key, required this.tags});
+
+  @override
+  Widget build(BuildContext context) {
+    return Autocomplete<Tag>(
+        optionsBuilder: (textEditingValue) {
+          final options = tags
+              .where((Tag tag) => tag.name
+                  .toLowerCase()
+                  .startsWith(textEditingValue.text.toLowerCase()))
+              .toList();
+
+          return options;
+        },
+
+        //
+        displayStringForOption: (Tag option) => option.name,
+
+        // on option select
+        onSelected: (tag) {
+          context.read<TagSelectorBloc>().add(AddTagEvent(tag));
+          controller?.text = '';
+          textFieldFocusNode?.unfocus();
+        },
+
+        //
+        optionsViewBuilder: (context, onSelected, options) {
+          return Align(
+            alignment: Alignment.topLeft,
+            child: Material(
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: Theme.of(context).colorScheme.surface,
+                ),
+                constraints: BoxConstraints(
+                  maxHeight: 200.h,
+                  maxWidth: 320.w,
+                ),
+                child: ListView.builder(
+                  padding: const EdgeInsets.all(10.0),
+                  shrinkWrap: true,
+                  itemCount: options.length,
+                  itemBuilder: (context, index) {
+                    final option = options.elementAt(index);
+
+                    return GestureDetector(
+                      onTap: () {
+                        onSelected(option);
+                      },
+                      child: ListTile(
+                        hoverColor: AppColors.gray400,
+                        title: Text(option.name,
+                            style: Theme.of(context).textTheme.bodyMedium),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+        },
+        fieldViewBuilder:
+            (context, textEditingController, focusNode, onFieldSubmitted) {
+          controller = textEditingController;
+          textFieldFocusNode = focusNode;
+
+          return CustomTextField(
+            controller: textEditingController,
+            focusNode: focusNode,
+            hintText: 'Add tags',
+          );
+        });
+  }
+}

--- a/aait/mobile/group-2/blog_app/lib/injection_container.dart
+++ b/aait/mobile/group-2/blog_app/lib/injection_container.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'core/constants/constants.dart';
 import 'core/network/custom_client.dart';
 import 'core/network/network_info.dart';
 import 'features/article/data/datasources/local/local.dart';
@@ -11,6 +12,7 @@ import 'features/article/data/repositories/article_repository_impl.dart';
 import 'features/article/domain/repositories/article_repository.dart';
 import 'features/article/domain/usecases/usecases.dart';
 import 'features/article/presentation/bloc/article_bloc.dart';
+import 'features/article/presentation/bloc/tag_selector_bloc.dart';
 
 final serviceLocator = GetIt.instance;
 
@@ -19,6 +21,7 @@ Future<void> init() async {
   // Bloc
   serviceLocator.registerFactory(
     () => ArticleBloc(
+      getTags: serviceLocator(),
       createArticle: serviceLocator(),
       deleteArticle: serviceLocator(),
       getAllArticles: serviceLocator(),
@@ -26,8 +29,14 @@ Future<void> init() async {
       updateArticle: serviceLocator(),
     ),
   );
+  serviceLocator.registerFactory(
+    () => TagSelectorBloc(),
+  );
 
   // Use cases
+  serviceLocator.registerLazySingleton(
+    () => GetTags(serviceLocator()),
+  );
   serviceLocator.registerLazySingleton(
     () => CreateArticle(serviceLocator()),
   );
@@ -48,7 +57,7 @@ Future<void> init() async {
   serviceLocator.registerLazySingleton<NetworkInfo>(
       () => NetworkInfoImpl(serviceLocator()));
   serviceLocator.registerLazySingleton<CustomClient>(
-      () => CustomClient(serviceLocator()));
+      () => CustomClient(serviceLocator(), apiBaseUrl: apiBaseUrl),);
 
   // Repository
   serviceLocator.registerLazySingleton<ArticleRepository>(

--- a/aait/mobile/group-2/blog_app/lib/main.dart
+++ b/aait/mobile/group-2/blog_app/lib/main.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import 'bloc_observer.dart';
 import 'core/presentation/router/router.dart';
 import 'core/presentation/theme/app_theme.dart';
+import 'injection_container.dart' as di;
 
-void main() {
+Future<void> main() async {
+  Bloc.observer = SimpleBlocObserver();
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await di.init();
+
   runApp(const App());
 }
 

--- a/aait/mobile/group-2/blog_app/linux/flutter/generated_plugin_registrant.cc
+++ b/aait/mobile/group-2/blog_app/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/aait/mobile/group-2/blog_app/linux/flutter/generated_plugins.cmake
+++ b/aait/mobile/group-2/blog_app/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/aait/mobile/group-2/blog_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/aait/mobile/group-2/blog_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,11 +5,13 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import path_provider_foundation
 import shared_preferences_foundation
 import sqflite
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/aait/mobile/group-2/blog_app/pubspec.yaml
+++ b/aait/mobile/group-2/blog_app/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   cached_network_image: ^3.2.3
   flutter_screenutil: ^5.9.0
   go_router: ^10.1.0
+  http_parser: ^4.0.2
+  image_picker: ^1.0.2
 
 dev_dependencies:
   flutter_test:

--- a/aait/mobile/group-2/blog_app/windows/flutter/generated_plugin_registrant.cc
+++ b/aait/mobile/group-2/blog_app/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
 }

--- a/aait/mobile/group-2/blog_app/windows/flutter/generated_plugins.cmake
+++ b/aait/mobile/group-2/blog_app/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Summary of changes:

Android Manifest:
- Add Internet permission

Bloc
- Add TagSelectorBloc, which is used inside create article screen to select tags
- Consumed ArticleBloc inside create article screen
- Add BlocObserver for debugging

Screen and Widgets:
- Refactored create article and article detail screens to use smaller components
- Add showError, showMessage and showSuccess functions to display message using SnackbarMessager

External Dependency:
- Add `image_picker` to select image from gallery
